### PR TITLE
💄 improve display of (struct) bureaucracy fields

### DIFF
--- a/css/plugins/bureaucracy.less
+++ b/css/plugins/bureaucracy.less
@@ -57,7 +57,6 @@
 
         span {
             float: left;
-            width: 50%;
             text-align: right;
             line-height: @line-height-default;
             padding-top: .2em;


### PR DESCRIPTION
Bureaucracy handles field width already responsively

ToDo
--------
- [ ]  The thanks message is way too narrow on mobile

This is also related to cosmocode/dokuwiki-plugin-struct#404