### PR TITLE
#30: Make logo clickable in Compact Mode

### DIFF
--- a/css/base_structure.less
+++ b/css/base_structure.less
@@ -172,6 +172,7 @@
             .row > .col-xs-12 {
                 height: auto;
                 min-height: fit-content;
+                z-index: 3;
             }
         }
     }


### PR DESCRIPTION
the col container needs a z-index that is higher than the z-index of the  top-header container