### PR TITLE
#29: Bugfix for IE11 in Compact Mode

### DIFF
--- a/css/base_structure.less
+++ b/css/base_structure.less
@@ -171,7 +171,7 @@
         .header {
             .row > .col-xs-12 {
                 height: auto;
-                min-height: fit-content;
+                min-height: auto;
             }
         }
     }


### PR DESCRIPTION
use min-height: auto instead of min-height: fit-content (intrinsic and extrinsic sizing module is neither supported by IE11 nor by Edge)