### PR TITLE
Enable loading local icons in sidebar nav

### DIFF
--- a/svg.php
+++ b/svg.php
@@ -2,7 +2,6 @@
 
 namespace dokuwiki\template\sprintdoc;
 
-define('NOSESSION', 1);
 if(!defined('DOKU_INC')) define('DOKU_INC', dirname(__FILE__) . '/../../../');
 require_once(DOKU_INC . 'inc/init.php');
 


### PR DESCRIPTION
A session needs to present, otherwise access to local media will be
denied, even if they are not ACL protected

Fixes #19