### PR TITLE
avoid flickering on scroll

### DIFF
--- a/css/area_content.less
+++ b/css/area_content.less
@@ -21,9 +21,13 @@
                 border-bottom: 1px solid @ini_border_light;
             }
 
-            .msg-area + * {
-                clear: both;
-                padding-top: 1em; // as h1
+            .page-content {
+                padding-top: @page-header_height;
+
+                .msg-area + * {
+                    clear: both;
+                    padding-top: 1em; // as h1
+                }
             }
         }
     }

--- a/main.php
+++ b/main.php
@@ -347,8 +347,10 @@ $classWideContent = ($ACT === "show") ? "": "wide-content ";
                                 echo $highlightParent->tpl();
                             }
                             ?>
-                            <div class="msg-area"><?php html_msgarea();/*msg('Information.', 0);msg('Success', 1);msg('Notification', 2);msg('Fehler', -1);*/ ?></div>
-                            <div class="clearer"></div>
+                            <div class="page-content">
+                                <div class="msg-area"><?php html_msgarea();/*msg('Information.', 0);msg('Success', 1);msg('Notification', 2);msg('Fehler', -1);*/ ?></div>
+                                <div class="clearer"></div>
+                            </div>
                             <?php
 
 


### PR DESCRIPTION
Previoulsy when position fixing the TOC on scroll the page got shorter.
This changed the scroll position which in certain circumstances could
unfix the TOC again, making the page longer again... this made the whole
page flicker like mad.

This should avoid shortening the page.

A proper fix would require to clean up the whole structuring of the HTML
and CSS, which would probably be a good idea but would require a lot of
effort.