### PR TITLE
Fix top margin for starred nav menu item

### DIFF
--- a/css/plugins/starred.less
+++ b/css/plugins/starred.less
@@ -27,8 +27,6 @@
 }
 
 nav.nav-starred {
-    margin-top: @nav-margin;
-
     ul {
         list-style: none;
 


### PR DESCRIPTION
There is no reason to have a margin above the starred menu item. Remove it.