### PR TITLE
Topbar and sidebar styling fixes

### DIFF
--- a/css/area_nav-usertools.less
+++ b/css/area_nav-usertools.less
@@ -66,34 +66,17 @@
                 border-radius: @ini_default_border_radius; // @ini_default_border_radius vs. @fix_border-radius
                 text-align: center;
                 margin: 0;
-
-                @media @screen_md-xlg {
-                    padding-top: .14rem;
-                }
             }
 
             /* !!! &.user-task FIND in plugins/do_tasks.less !!! */
             &.user {
                 position: relative;
-                display: table-cell;
+                display: table;
                 background-color: @ini_background_site;
                 border: solid 1px @wikiicons-border;
                 border-radius: @ini_default_border_radius; // @ini_default_border_radius vs. @fix_border-radius
                 color: @ini_text_webframe;
                 padding-right: .3rem;
-
-                @media @screen_min-md {
-                    padding-top: .35rem;
-                }
-
-                @media @screen_max-md {
-                    min-height: @toggle-size;
-                    padding-top: .3rem;
-                }
-
-                @media @screen_max-sm {
-                    padding-top: .35rem;
-                }
 
                 @media @screen_max-xs {
                     position: absolute;
@@ -102,14 +85,19 @@
                     overflow: hidden;
                     white-space: nowrap;
                     margin: -1px 0 0;
-                    padding-top: .4rem;
                 }
 
                 @media @screen_max-xxs {
                     left: -10px;
                     right: 0;
                     width: auto;
-                    padding-top: .35rem;
+                }
+
+                > span {
+                    display: table-cell;
+                    vertical-align: middle;
+                    border: unset;
+                    min-width: unset;
                 }
 
                 > a {
@@ -200,19 +188,6 @@
                         left: -2px;
                         font-size: 1.4rem;
                         margin: 0;
-
-                        @media @screen_min-xxlg {
-                            top: -.25rem;
-                        }
-
-                        @media @screen_max-xxlg {
-                            top: -.2rem;
-                        }
-
-                        @media @screen_max-xs {
-                            top: -.25rem;
-
-                        }
                     }
                 }
             } // user
@@ -302,11 +277,13 @@
 
                 li.user {
                     color: @ini_background_site;
+                    margin: 0;
 
                     bdi {
                         position: absolute;
                         width: 0;
                         padding: 0;
+                        margin: 0;
                         text-indent: -10000px;
 
                         &:before {
@@ -314,6 +291,7 @@
                             background-color: @ini_background_site;
                             color: @ini_nav_menu_color;
                             text-indent: 0;
+                            left: -4px;
                         }
                     }
 

--- a/css/plugins/starred.less
+++ b/css/plugins/starred.less
@@ -27,8 +27,6 @@
 }
 
 nav.nav-starred {
-    margin-top: @nav-margin;
-
     ul {
         list-style: none;
 

--- a/tpl/nav-usertools-buttons.php
+++ b/tpl/nav-usertools-buttons.php
@@ -22,7 +22,7 @@
 
                 <?php
                 if (!empty($_SERVER['REMOTE_USER'])) {
-                    echo '<li class="user"><span class="sr-only">'.$lang['loggedinas'].' </span>'.userlink().'</li>';
+                    echo '<li class="user"><span><span class="sr-only">'.$lang['loggedinas'].' </span>'.userlink().'</span></li>';
                 }?>
 
                 <?php /* dokuwiki user tools */


### PR DESCRIPTION
This PR contains two styling fixes. This was tested with Firefox 88 and Chromium 90.

- Remove the spacing above the starred plugin menu entry
- Fix the user tools alignment. This also simplifies and fixes the CSS that is partly invalid (display: table-cell in floating element).
  | Before | After |
  | --------- | ------- |
  | ![image](https://user-images.githubusercontent.com/34034373/116719699-ac627e00-a9db-11eb-8304-034e676eb7df.png) | ![image](https://user-images.githubusercontent.com/34034373/116719577-83da8400-a9db-11eb-9035-d28d734592d9.png) |