### PR TITLE
Correctly interpret result of strpos(…)

### DIFF
--- a/tpl.php
+++ b/tpl.php
@@ -45,7 +45,7 @@ class tpl {
                       $linktarget = wl($data['id'], $data['params'], false, '&');
                   }
       $caption = $lang['btn_' . $data['type']];
-      if(strpos($caption, '%s')) {
+      if(strpos($caption, '%s') !== false) {
                       $caption = sprintf($caption, $data['replacement']);
                   }
 


### PR DESCRIPTION
if `%s` happens to be at the start of the string then `strpos(…, '%s')` returns `0`. That evaluates to false in an `if` statement. Thus the replacement will not be applied in that case. See https://github.com/splitbrain/dokuwiki/pull/3790 for a probable similar issue.